### PR TITLE
sepolicy: Additional policy for LiveDisplay

### DIFF
--- a/sepolicy/livedisplay.te
+++ b/sepolicy/livedisplay.te
@@ -1,2 +1,6 @@
 # Various knobs used by LiveDisplay
 allow system_server livedisplay_sysfs:file rw_file_perms;
+
+# Storage of default mode
+allow system_server display_misc_file:dir r_dir_perms;
+allow system_server display_misc_file:file create_file_perms;


### PR DESCRIPTION
 * LiveDisplay needs to store the user-selected default mode somewhere
   in the case where we are mixing local sysfs-style modes with QDCM
   modes. Add a rule for this.

Change-Id: I42b80df7c0ee3c2815594c8a6feea3dc078c6ae2